### PR TITLE
WIP: Fix catkin_lint warnings

### DIFF
--- a/battery_guard/CMakeLists.txt
+++ b/battery_guard/CMakeLists.txt
@@ -1,7 +1,9 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(battery_guard)
 
-find_package(catkin REQUIRED)
+find_package(catkin REQUIRED COMPONENTS
+    rospy
+)
 
 catkin_package(
 	CATKIN_DEPENDS rospy sound_play


### PR DESCRIPTION
I only fixed one warning:

```
battery_guard: warning: unconfigured build_depend on 'rospy'
```

I have no idea how to fix this:
```
simple_approximate_time_synchronizer: warning: executable file 'src/simple_approximate_time_synchronizer/__init__.py' is not installed
```

Actually, I have no experience with CMake or ROS at all, so better take a good look at the changes before merging. If someone can give me a hint on how to fix the second warning, I'd appreciate it!

Fixes #21 