### PR TITLE
Add missing xacro tags for inertials with origin

### DIFF
--- a/uos_common_urdf/common.xacro
+++ b/uos_common_urdf/common.xacro
@@ -40,7 +40,7 @@
   <xacro:macro name="sphere_inertial_with_origin" params="radius mass *origin">
     <inertial>
       <mass value="${mass}" />
-      <insert_block name="origin" />
+      <xacro:insert_block name="origin" />
       <inertia ixx="${0.4 * mass * radius * radius}" ixy="0.0" ixz="0.0"
         iyy="${0.4 * mass * radius * radius}" iyz="0.0"
         izz="${0.4 * mass * radius * radius}" />
@@ -50,7 +50,7 @@
   <xacro:macro name="cylinder_inertial_with_origin" params="radius length mass *origin">
     <inertial>
       <mass value="${mass}" />
-      <insert_block name="origin" />
+      <xacro:insert_block name="origin" />
       <inertia ixx="${0.0833333 * mass * (3 * radius * radius + length * length)}" ixy="0.0" ixz="0.0"
         iyy="${0.0833333 * mass * (3 * radius * radius + length * length)}" iyz="0.0"
         izz="${0.5 * mass * radius * radius}" />
@@ -60,7 +60,7 @@
   <xacro:macro name="box_inertial_with_origin" params="x y z mass *origin">
     <inertial>
       <mass value="${mass}" />
-      <insert_block name="origin" />
+      <xacro:insert_block name="origin" />
       <inertia ixx="${0.0833333 * mass * (y*y + z*z)}" ixy="0.0" ixz="0.0"
         iyy="${0.0833333 * mass * (x*x + z*z)}" iyz="0.0"
         izz="${0.0833333 * mass * (x*x + y*y)}" />


### PR DESCRIPTION
Thanks for this useful file. The `insert_block` tags have to be prefixed with `xacro:` in order for them to work! Xacro / RViz / Gazebo don't throw an error if you omit the prefix so this was difficult to spot, and is therefore present in other repos on github that use this file..